### PR TITLE
docs: add defaults and comments to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,36 @@
 
 # Server
-HOST=
-PORT=
+# Host interface the server binds to (use 0.0.0.0 for Docker)
+HOST=0.0.0.0
+# HTTP port the server listens on
+PORT=1337
 
 # Secrets
-APP_KEYS=
-API_TOKEN_SALT=
-ADMIN_JWT_SECRET=
-TRANSFER_TOKEN_SALT=
+# Comma-separated keys for signing cookies
+APP_KEYS=appKey1,appKey2
+# Salt used when generating API tokens
+API_TOKEN_SALT=apiTokenSalt
+# Secret used to sign admin JWTs
+ADMIN_JWT_SECRET=adminJwtSecret
+# Salt for transfer token generation
+TRANSFER_TOKEN_SALT=transferTokenSalt
+# Secret used to sign user JWTs
+JWT_SECRET=jwtSecret
 
 # Database
-DATABASE_CLIENT=
-DATABASE_HOST=
-DATABASE_PORT=
-DATABASE_NAME=
-DATABASE_USERNAME=
-DATABASE_PASSWORD=
-DATABASE_SSL=
-DATABASE_FILENAME=
-JWT_SECRET=
+# Database client to use (e.g. postgres, mysql, sqlite)
+DATABASE_CLIENT=postgres
+# Database host; in Docker, use the service name (e.g. "postgres")
+DATABASE_HOST=postgres
+# Database port
+DATABASE_PORT=5432
+# Name of the database
+DATABASE_NAME=strapi
+# Username for the database connection
+DATABASE_USERNAME=strapi
+# Password for the database connection
+DATABASE_PASSWORD=strapi
+# Enable SSL connection (set to true in production)
+DATABASE_SSL=false
+# SQLite file path (only used when DATABASE_CLIENT=sqlite)
+DATABASE_FILENAME=.tmp/data.db


### PR DESCRIPTION
## Summary
- populate `.env.example` with representative defaults for server, secrets, and database config
- add comments explaining each variable and docker-related usage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c40208a348320872128e0bffa0ed2