### PR TITLE
Configure CORS to use frontend origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # Server
 HOST=
 PORT=
+FRONTEND_URL=
 
 # Secrets
 APP_KEYS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:20-alpine AS build
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev git > /dev/null 2>&1
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
+ARG FRONTEND_URL
+ENV FRONTEND_URL=${FRONTEND_URL}
 ENV PATH=/opt/node_modules/.bin:$PATH
 
 WORKDIR /opt/
@@ -17,6 +19,8 @@ RUN npm run build
 FROM node:20-alpine
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
+ARG FRONTEND_URL
+ENV FRONTEND_URL=${FRONTEND_URL}
 ENV PATH=/opt/node_modules/.bin:$PATH
 
 RUN apk add --no-cache vips-dev

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,12 @@ docker-run: docker-build
 		-e DATABASE_PORT=$(DATABASE_PORT) \
 		-e DATABASE_NAME=$(DATABASE_NAME) \
 		-e DATABASE_USERNAME=$(DATABASE_USERNAME) \
-		-e DATABASE_PASSWORD=$(DATABASE_PASSWORD) \
-		-e DATABASE_SSL=$(DATABASE_SSL) \
-		-e DATABASE_FILENAME=$(DATABASE_FILENAME) \
-		-e JWT_SECRET=$(JWT_SECRET) \
-		$(REPOSITORY)/$(TARGET):$(DOCKERTAG)
+                -e DATABASE_PASSWORD=$(DATABASE_PASSWORD) \
+                -e DATABASE_SSL=$(DATABASE_SSL) \
+                -e DATABASE_FILENAME=$(DATABASE_FILENAME) \
+                -e JWT_SECRET=$(JWT_SECRET) \
+                -e FRONTEND_URL=$(FRONTEND_URL) \
+                $(REPOSITORY)/$(TARGET):$(DOCKERTAG)
 
 deploy:
 	ansible-playbook deployments/ansible/deploy.yml -vv 

--- a/config/middlewares.ts
+++ b/config/middlewares.ts
@@ -1,8 +1,13 @@
-export default [
+export default ({ env }) => [
   'strapi::logger',
   'strapi::errors',
   'strapi::security',
-  'strapi::cors',
+  {
+    name: 'strapi::cors',
+    config: {
+      origin: env.array('FRONTEND_URL', ['http://localhost:3000']),
+    },
+  },
   'strapi::poweredBy',
   'strapi::query',
   'strapi::body',


### PR DESCRIPTION
## Summary
- configure CORS middleware to read allowed origins from FRONTEND_URL env
- supply FRONTEND_URL in Dockerfile, Makefile and .env.example

## Testing
- `npm test` *(fails: Missing script: "test")*
- `APP_KEYS=test API_TOKEN_SALT=test ADMIN_JWT_SECRET=test TRANSFER_TOKEN_SALT=test DATABASE_CLIENT=sqlite DATABASE_FILENAME=.tmp/data.db JWT_SECRET=test FRONTEND_URL=http://localhost:3000 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c4022c26883208ae08ec8267dfbcd