### PR TITLE
feat(article): add location fields

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -72,6 +72,8 @@
         "id": 1
       },
       "description": "Follow the story of Aaron Swartz, the boy who could change the world",
+      "latitude": 37.7749,
+      "longitude": -122.4194,
       "cover": null,
       "blocks": [
         {
@@ -107,6 +109,8 @@
         "id": 1
       },
       "description": "Mantis shrimps, or stomatopods, are marine crustaceans of the order Stomatopoda.",
+      "latitude": 34.0522,
+      "longitude": -118.2437,
       "cover": null,
       "blocks": [
         {
@@ -142,6 +146,8 @@
         "id": 2
       },
       "description": "How a bug on MySQL is becoming a meme on the internet",
+      "latitude": 40.7128,
+      "longitude": -74.0060,
       "cover": null,
       "blocks": [
         {
@@ -177,6 +183,8 @@
         "id": 2
       },
       "description": "Description of a beautiful picture",
+      "latitude": 51.5074,
+      "longitude": -0.1278,
       "cover": null,
       "blocks": [
         {
@@ -212,6 +220,8 @@
         "id": 2
       },
       "description": "Maybe the answer is in this article, or not...",
+      "latitude": 35.6895,
+      "longitude": 139.6917,
       "cover": null,
       "blocks": [
         {

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -171,10 +171,14 @@ async function importArticles() {
     const cover = await checkFileExistsBeforeUpload([`${article.slug}.jpg`]);
     const updatedBlocks = await updateBlocks(article.blocks);
 
+    const { latitude, longitude, ...rest } = article;
+
     await createEntry({
       model: 'article',
       entry: {
-        ...article,
+        ...rest,
+        latitude,
+        longitude,
         cover,
         blocks: updatedBlocks,
         // Make sure it's not a draft

--- a/src/api/article/content-types/article/schema.json
+++ b/src/api/article/content-types/article/schema.json
@@ -44,6 +44,12 @@
     "blocks": {
       "type": "dynamiczone",
       "components": ["shared.media", "shared.quote", "shared.rich-text", "shared.slider"]
+    },
+    "latitude": {
+      "type": "decimal"
+    },
+    "longitude": {
+      "type": "decimal"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -423,12 +423,14 @@ export interface ApiArticleArticle extends Struct.CollectionTypeSchema {
       Schema.Attribute.SetMinMaxLength<{
         maxLength: 80;
       }>;
+    latitude: Schema.Attribute.Decimal;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::article.article'
     > &
       Schema.Attribute.Private;
+    longitude: Schema.Attribute.Decimal;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.UID<'title'>;
     title: Schema.Attribute.String;


### PR DESCRIPTION
## Summary
- add latitude and longitude fields to Article content-type
- update TypeScript typings
- seed articles with coordinates and propagate via seed script

## Testing
- `npx strapi ts:generate-types` *(fails: Cannot find module 'better-sqlite3')*
- `npm install better-sqlite3` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c4014e6dc8320b7af0011a514e1e0